### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ dmypy.json
 
 # PyCharm files
 .idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,17 +4,25 @@ Wrapper for boto3 library, created to be used with [Wasabi Hot Cloud Storage](ht
 Wasabi is S3 compatible, so it can be used with `boto3` by overriding AWS-related parameters.
 Created client is usual `boto3` S3 clint, so can be used in usual manner.
 
-#### Example:
+#### Examples:
 
 ```python
-from wasabis3 import get_client
+from wasabis3 import WasabiStorage
 
-wasabi = get_client('<WASABI_SECRET_ACCESS_KEY_ID>', '<WASABI_SECRET_ACCESS_KEY>')
+wasabi = WasabiStorage('<WASABI_SECRET_ACCESS_KEY_ID>', '<WASABI_SECRET_ACCESS_KEY>', '<WASABI_BUCKET_REGION>')
 
-resp = wasabi.list_buckets()
+resp = wasabi.client.list_buckets()
 
 buckets = [bucket['Name'] for bucket in resp['Buckets']]
 
 print(buckets)
 
+```
+
+```python
+from wasabis3 import WasabiStorage
+
+wasabi = WasabiStorage('<WASABI_SECRET_ACCESS_KEY_ID>', '<WASABI_SECRET_ACCESS_KEY>', '<WASABI_BUCKET_REGION>')
+
+wasabi.upload('<FILE_PATH>', '<WASABI_BUCKET_NAME>', '<FILE_NAME_ON_THE_CLOUD>')
 ```

--- a/wasabis3/__init__.py
+++ b/wasabis3/__init__.py
@@ -1,1 +1,1 @@
-from .wasabi import get_client
+from .wasabi import WasabiStorage

--- a/wasabis3/wasabi.py
+++ b/wasabis3/wasabi.py
@@ -1,24 +1,7 @@
-from boto3 import client
-
-SERVICE_ENDPOINT = 'https://s3.wasabisys.com'
+import boto3
 
 
-def get_client(access_key_id,
-               secret_access_key,
-               session_token=None):
-    """
-    Factory function that creates `Wasabi storage` client.
-
-    :param access_key_id: access id for `Wasabi`
-    :param secret_access_key: secret key for `Wasabi`
-    :param session_token: session token for `Wasabi`
-    :return: s3 client, attached to Wasabi service
-    """
-    storage = _WasabiStorage(access_key_id, secret_access_key, session_token).storage
-    return storage
-
-
-class _WasabiStorage:
+class WasabiStorage:
     """
     Wraps S3 client from `boto3` library.
     Overrides AWS endpoint and uses Wasabi credentials to create compatible client.
@@ -27,11 +10,26 @@ class _WasabiStorage:
     def __init__(self,
                  access_key_id,
                  secret_access_key,
+                 region,
                  session_token=None):
-        self.storage = client(
+        self.client = boto3.client(
             's3',
             aws_access_key_id=access_key_id,
             aws_secret_access_key=secret_access_key,
             aws_session_token=session_token,
-            endpoint_url=SERVICE_ENDPOINT
+            endpoint_url='https://s3.{}.wasabisys.com'.format(region)
         )
+
+    def upload(self, file_path, bucket_name, wasabi_file_name):
+        """ Upload file to specific bucket
+
+        :type file_path: str
+        :param file_path: The path of file.
+
+        :type bucket_name: str
+        :param bucket_name: The name of bucket that you want to upload the file on it.
+
+        :type wasabi_file_name: str
+        :param wasabi_file_name: File name on Wasabi Cloud
+        """
+        self.client.upload_file(file_path, bucket_name, wasabi_file_name)


### PR DESCRIPTION
According to Wasabi [documentation](https://wasabi.com/wp-content/themes/wasabi/docs/API_Guide/index.html#t=topics%2Fapidiff-intro.htm), you must include the region of the bucket in the endpoint URL, so you can access to buckets for uploading or downloading or anything like AWS.
Added function to upload files in the cloud.